### PR TITLE
Add ImagePullSecrets support

### DIFF
--- a/charts/cert-manager-webhook-gandi/templates/deployment.yaml
+++ b/charts/cert-manager-webhook-gandi/templates/deployment.yaml
@@ -66,3 +66,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/cert-manager-webhook-gandi/values.yaml
+++ b/charts/cert-manager-webhook-gandi/values.yaml
@@ -37,3 +37,5 @@ affinity: {}
 # -- To not store it in plain text, use sops or similar.
 # -- The secret is not created if not set.
 gandiApiToken: ""
+# -- Image pull secrets
+imagePullSecrets: []


### PR DESCRIPTION

### Description
This PR adds support for imagePullSecrets in the Helm chart to allow pulling images from private registries that require authentication.
### Changes
Added imagePullSecrets parameter in values.yaml (default: empty list)
Added corresponding configuration in the deployment.yaml template to inject secrets into the pod spec
### Usage
To use this feature, simply define the secrets in your values:
```
imagePullSecrets:  
  - name: my-registry-secret
```
The secrets must be created beforehand in the target namespace.
### Notes
The configuration is optional (uses {{- with .Values.imagePullSecrets }})
If not defined or empty, no imagePullSecrets will be added to the deployment