### PR TITLE
feat: add sharingId support for Gandi reseller/resellee domains

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,11 @@ type gandiDNSProviderConfig struct {
 	// `issuer.spec.acme.dns01.providers.webhook.config` field.
 	APIKeySecretRef cmmeta.SecretKeySelector `json:"apiKeySecretRef"`
 	PatSecretRef    cmmeta.SecretKeySelector `json:"patSecretRef"`
+	// SharingID is the Gandi organisation UUID required when the domain is owned
+	// by a resellee sub-organisation. Without it the LiveDNS API returns 404 for
+	// write operations on resellee domains even with a valid reseller PAT.
+	// Obtain it from: GET https://api.gandi.net/v5/organization/organizations
+	SharingID string `json:"sharingId,omitempty"`
 }
 
 // Name is used as the name for this DNS solver when referencing it on the ACME
@@ -250,7 +255,7 @@ func (c *gandiDNSProviderSolver) getSecret(keySelector *cmmeta.SecretKeySelector
 
 // Init Client configuration
 func (c *gandiDNSProviderSolver) initClientConfigCredentials(cfg *gandiDNSProviderConfig, namespace string) (*config.Config, error) {
-	clientcfg := &config.Config{}
+	clientcfg := &config.Config{SharingID: cfg.SharingID}
 	//
 	apiKey, err := c.getSecret(&cfg.APIKeySecretRef, namespace)
 	if err != nil {


### PR DESCRIPTION
## Problem

Domains owned by a **Gandi resellee sub-organisation** return \`HTTP 404\` on any LiveDNS write
operation (create/update/delete TXT record) when authenticated with a reseller PAT — even when
the PAT has full domain-management permissions.

This is because the [Gandi API requires a \`sharing_id\` query parameter](https://api.gandi.net/docs/reference/#section/Resellers)
to scope write requests to a resellee's organisation. Without it, the resource is not found from
the reseller's context.

\`\`\`
HTTP 404 — {"code":404,"cause":"Unknown","message":"The resource does not exist"}
\`\`\`

The same PAT works fine for domains directly owned by the reseller account (e.g. \`.com\`, \`.co\`).
Only domains scoped to a resellee sub-org are affected.

## Root Cause

\`gandiDNSProviderConfig\` did not include a \`SharingID\` field, so there was no way for an operator
to pass the resellee organisation UUID through the ClusterIssuer config. The underlying
\`go-gandi\` client already supports \`SharingID\` in \`config.Config\` (see
[go-gandi/config/config.go](https://github.com/go-gandi/go-gandi/blob/main/config/config.go)) —
it simply was not wired up.

## Fix

Two minimal changes in \`main.go\`:

1. Add optional \`sharingId\` field to \`gandiDNSProviderConfig\`
2. Initialise \`config.Config\` with \`SharingID\` from the parsed config

**Diff is 6 lines (+5 / -1).**

## Usage (after fix)

\`\`\`yaml
solvers:
- dns01:
    webhook:
      groupName: acme.gandi.net
      solverName: gandi
      config:
        patSecretRef:
          key: pat
          name: <your-secret-name>
        sharingId: "<resellee-org-uuid>"
\`\`\`

Obtain the \`sharingId\` via:
\`\`\`
GET https://api.gandi.net/v5/organization/organizations
\`\`\`

The field is \`omitempty\` — existing configs without it continue to work unchanged.

## Tested

Validated against a real Gandi reseller account where domains are owned by a resellee
sub-organisation. Without the fix, cert-manager challenges fail with 404. With the fix applied
locally, the TXT record is created successfully and the certificate reaches \`Ready: True\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)