### PR TITLE
Fix/concurrent txt challenges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: sintef/cert-manager-webhook-gandi
+  IMAGE_NAME: freuds/cert-manager-webhook-gandi
 
 jobs:
   build-and-push-image:
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Get versions
         id: versions
         run: |
           echo go_version=$(go mod edit -json | grep -Po '"Go":\s+"([0-9.]+)"' | sed -E 's/.+"([0-9.]+)"/\1/') >> $GITHUB_OUTPUT
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -39,15 +39,15 @@ jobs:
 
       - name: Extract metadata (tags, labels) for pre process image
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0e
 
       - name: Configure Git
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 | Date | Version | Description |
 | ------ | ------ | ------ |
+| 2026-07-12 | v0.6.1 | fix concurrent DNS-01 challenges on the same FQDN (apex + wildcard):<br>Present now appends the TXT value to the existing rrset instead of replacing it<br>CleanUp now removes only the challenge's own value and deletes the record only when empty |
 | 2021-10-11 | v0.3.0 | SINTEF fork version |
 | 2021-10-11 | v0.2.0 | add chart-releaser GitHub action |
 | 2021-10-06 | v0.2.0 | update cert-manager to 1.5.4<br>update k8s API version to 0.22.2<br>migrate to new LiveDNS API (https://api.gandi.net)<br>add Helm repo with GitHub pages<br>simplify Dockerfile & switch to Buildx<br>update make test target (remove shell script)<br>update README.md with changes made<br>update GitHub workflow with Buildx<br>add k8s APF support (k8s >= 1.20) |

--- a/charts/cert-manager-webhook-gandi/Chart.yaml
+++ b/charts/cert-manager-webhook-gandi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 description: A Helm chart for cert-manager-webhook-gandi
 name: cert-manager-webhook-gandi
-version: v0.6.0
-appVersion: 0.6.0
+version: v0.6.1
+appVersion: 0.6.1

--- a/charts/cert-manager-webhook-gandi/values.yaml
+++ b/charts/cert-manager-webhook-gandi/values.yaml
@@ -9,7 +9,7 @@ certManager:
   serviceAccountName: cert-manager
 image:
   # -- Image name
-  repository: ghcr.io/sintef/cert-manager-webhook-gandi
+  repository: ghcr.io/freuds/cert-manager-webhook-gandi
   # -- Image tag (default to Chart's appVersion)
   tag: ""
   # -- Image pull policy

--- a/main.go
+++ b/main.go
@@ -128,15 +128,32 @@ func (c *gandiDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 			return fmt.Errorf("unable to create TXT record: %v", err)
 		}
 	} else {
-		if strings.Join(record.RrsetValues, "") != "\""+ch.Key+"\"" {
-			klog.V(6).Infof("Current record exists for %s value is %s, new value will be \"%s\"", subdomain+root, strings.Join(record.RrsetValues, ""), ch.Key)
-			_, err := gandiClient.UpdateDomainRecordByNameAndType(root, subdomain, "TXT", GandiMinTtl, []string{ch.Key})
-			if err != nil {
-				return fmt.Errorf("unable to update TXT record: %v", err)
+		// The record may already hold values for other in-flight challenges on
+		// the same FQDN (e.g. apex + wildcard of the same certificate): append
+		// the new value instead of replacing the whole rrset.
+		values := make([]string, 0, len(record.RrsetValues)+1)
+		for _, v := range record.RrsetValues {
+			if unquoteTxtValue(v) == ch.Key {
+				klog.V(6).Infof("Value \"%s\" already present for %s, nothing to do", ch.Key, subdomain+"."+root)
+				return nil
 			}
+			values = append(values, unquoteTxtValue(v))
+		}
+		values = append(values, ch.Key)
+		klog.V(6).Infof("Current record exists for %s with %d value(s), appending value \"%s\"", subdomain+"."+root, len(record.RrsetValues), ch.Key)
+		_, err := gandiClient.UpdateDomainRecordByNameAndType(root, subdomain, "TXT", GandiMinTtl, values)
+		if err != nil {
+			return fmt.Errorf("unable to update TXT record: %v", err)
 		}
 	}
 	return nil
+}
+
+// unquoteTxtValue strips the surrounding double quotes the Gandi LiveDNS API
+// adds around TXT rrset values, so values can be compared and resubmitted
+// without double quoting.
+func unquoteTxtValue(value string) string {
+	return strings.Trim(value, "\"")
 }
 
 // CleanUp should delete the relevant TXT record from the DNS provider console.
@@ -172,13 +189,31 @@ func (c *gandiDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
 		return fmt.Errorf("unable to mange provided domain : %v", err)
 	}
 
-	_, err = gandiClient.GetDomainRecordByNameAndType(root, subdomain, "TXT")
+	record, err := gandiClient.GetDomainRecordByNameAndType(root, subdomain, "TXT")
 	if err != nil {
 		klog.V(6).Infof("There is no entry of TXT matching, do nothing: %v", err)
-	} else {
-		err := gandiClient.DeleteDomainRecord(root, subdomain, "TXT")
-		if err != nil {
+		return nil
+	}
+
+	// Only remove the value belonging to this challenge: the rrset may hold
+	// values for other in-flight challenges on the same FQDN (e.g. apex +
+	// wildcard of the same certificate).
+	remaining := make([]string, 0, len(record.RrsetValues))
+	for _, v := range record.RrsetValues {
+		if unquoteTxtValue(v) != ch.Key {
+			remaining = append(remaining, unquoteTxtValue(v))
+		}
+	}
+
+	if len(remaining) == 0 {
+		klog.V(6).Infof("No remaining TXT value for %s, deleting the record", subdomain+"."+root)
+		if err := gandiClient.DeleteDomainRecord(root, subdomain, "TXT"); err != nil {
 			return fmt.Errorf("unable to delete TXT record: %v", err)
+		}
+	} else if len(remaining) < len(record.RrsetValues) {
+		klog.V(6).Infof("%d TXT value(s) remaining for %s, removing only value \"%s\"", len(remaining), subdomain+"."+root, ch.Key)
+		if _, err := gandiClient.UpdateDomainRecordByNameAndType(root, subdomain, "TXT", GandiMinTtl, remaining); err != nil {
+			return fmt.Errorf("unable to update TXT record: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Present : si le record TXT _acme-challenge existe déjà, la nouvelle valeur est ajoutée au rrset existant (avec normalisation des quotes Gandi via un helper unquoteTxtValue) au lieu de remplacer l'ensemble ; si la valeur y est déjà, no-op.
CleanUp : ne retire que la valeur du challenge concerné, et ne supprime le record que s'il ne reste aucune valeur — exactement ce que demande le contrat cert-manager cité en commentaire de la fonction.
go build, go vet et gofmt passent. Le CHANGELOG et le chart sont bumpés en v0.6.1.